### PR TITLE
Omit clobber if it is an empty string.

### DIFF
--- a/templates/sumo.conf.j2
+++ b/templates/sumo.conf.j2
@@ -24,6 +24,6 @@ override={{ sumologic_collector_override }}
 {% if sumologic_collector_ephemeral is defined %}
 ephemeral={{ sumologic_collector_ephemeral }}
 {% endif %}
-{% if sumologic_collector_clobber is defined %}
+{% if sumologic_collector_clobber is defined and sumologic_collector_clobber != "" %}
 clobber={{ sumologic_collector_clobber }}
 {% endif %}


### PR DESCRIPTION
sumologic_collector_clobber defaults to ""

Previously, this resulted in an invalid configuration, with

```
clobber=
```

inserted into the sumo.conf.

Now, the template will omit this line if sumologic_collector_clobber
is "" or undefined.