### PR TITLE
Added support for using local file configuration management

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,6 +16,11 @@ sumologic_collector_accesskey: ""
 #   https://service.sumologic.com/help/Default.htm#Using_Clobber.htm
 sumologic_collector_clobber: ""
 
+# Manage this collector, and all of its sources, by deploying a configuration file that can be read locally by this collector.
+# This will disable the ability to edit its sources from the UI and the REST API.
+# See: https://service.sumologic.com/help/Default.htm#cshid=1039
+sumologic_collector_use_local_config: ""
+
 sumologic_installer_file: ""
 sumologic_collector_source_template: "collector.json.j2"
 sumologic_collector_timezone: "UTC"

--- a/templates/sumo.conf.j2
+++ b/templates/sumo.conf.j2
@@ -18,6 +18,9 @@ accesskey={{ sumologic_collector_accesskey }}
 {% if sumologic_collector_source_template is defined %}
 sources=/etc/sumologic-collector.json
 {% endif %}
+{% if sumologic_collector_use_local_config is defined and sumologic_collector_use_local_config != "" %}
+syncSources=/etc/sumologic-collector.json
+{% endif %}
 {% if sumologic_collector_override is defined %}
 override={{ sumologic_collector_override }}
 {% endif %}


### PR DESCRIPTION
The `syncSources` option will disable management of the collector sources via the web UI and allow it to be fully managed by local configuration, which is a likely use case for people using this Ansible module in the first place.

I've set a default value that leaves it off for backwards compatibility. Since `/etc/sumologic-collector.json` is the default value for `sources` anyway, there isn't any point in letting someone specify a different path for `syncSources`, so it will merely use the same default.