### PR TITLE
Install fixes per docs

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,8 +1,4 @@
 ---
-
-
 - name: 'Restart SumoCollector'
-  service:
-    name: collector
-    state: restarted
+  command: "/opt/SumoCollector/collector restart"
   tags: [sumologic, sumologic-collector]

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,37 +12,12 @@
   when: sumologic_collector_deb_check.rc == 1
   tags: sumologic
 
-- name: 'Install SumoCollector'
-  apt:
-    deb: '{{ sumologic_installer_remote_file }}'
-    state: installed
-  when: sumologic_collector_deb_check.rc == 1
-  tags: sumologic
-  notify: Restart SumoCollector
-
-
 - name: 'Download SumoCollector redhat'
   get_url:
     url: '{{ sumocollector_installer_rpm }}'
     dest: '{{ sumologic_installer_rpm_local_folder }}/sumo_collector.rpm'
   when: ansible_os_family == "RedHat"
   tags: sumologic
-
-- name: 'Install SumoCollector redhat'
-  yum:
-    name: '{{ sumologic_installer_rpm_local_folder }}/sumo_collector.rpm'
-    state: present
-  when: ansible_os_family == "RedHat"
-  tags: sumologic
-  notify: Restart SumoCollector
-
-- name: 'Configure SumoCollector'
-  template:
-    src: sumo.conf.j2
-    dest: /etc/sumo.conf
-  register: sumologic_collector_add_configuration
-  tags: sumologic
-  notify: Restart SumoCollector
 
 - name: 'Define initial SumoCollector sources'
   set_fact:
@@ -54,4 +29,28 @@
     src: collector.json.j2
     dest: /etc/sumologic-collector.json
   tags: [sumologic, sumologic-collector]
+  notify: Restart SumoCollector
+
+- name: 'Configure SumoCollector'
+  template:
+    src: sumo.conf.j2
+    dest: /etc/sumo.conf
+  register: sumologic_collector_add_configuration
+  tags: sumologic
+  notify: Restart SumoCollector
+
+- name: 'Install SumoCollector'
+  apt:
+    deb: '{{ sumologic_installer_remote_file }}'
+    state: installed
+  when: sumologic_collector_deb_check.rc == 1
+  tags: sumologic
+  notify: Restart SumoCollector
+
+- name: 'Install SumoCollector redhat'
+  yum:
+    name: '{{ sumologic_installer_rpm_local_folder }}/sumo_collector.rpm'
+    state: present
+  when: ansible_os_family == "RedHat"
+  tags: sumologic
   notify: Restart SumoCollector


### PR DESCRIPTION
According to the official documentation and the official Sumologic Chef cookbooks:

1. The sumo.conf file is used during installation and then never again ([docs](https://service.sumologic.com/help/Installing_a_Collector_with_RPM.htm) | [cookbook](https://github.com/SumoLogic/sumologic-collector-chef-cookbook/blob/master/recipes/default.rb#L43)), so it should be configured prior to installation.
2. The collector should be restarted using the script installed in the SumoCollector directory ([docs](https://service.sumologic.com/help/Starting_or_Stopping_a_Collector.htm) | [cookbook](https://github.com/SumoLogic/sumologic-collector-chef-cookbook/blob/master/attributes/default.rb#L95-L96))

With regard to item 2, using the `service` module actually doesn't work correctly with the latest version of Ansible... it complains that systemd can't find the requested service `collector` (but it does work if you just run `service collector restart` from the command line).

Anyway, as far as I know, this PR should not break backwards compatibility for anybody using a previous version, and it is consistent with what Sumologic recommends in their documentation and do in their cookbook. I hope you will find it acceptable to merge.

Thanks!