### PR TITLE
adding optional prefix_regexp property to control multiline prefix matching

### DIFF
--- a/templates/collector.json.j2
+++ b/templates/collector.json.j2
@@ -7,7 +7,10 @@
       "sourceType": "LocalFile",
       "automaticDateParsing": true,
       "multilineProcessingEnabled": "{{ source.use_multiline }}",
-      "useAutolineMatching": true,
+      "useAutolineMatching": {{'false' if source.prefix_regexp is defined else 'true'}},
+      {% if source.prefix_regexp is defined %}
+      "manualPrefixRegexp": "{{source.prefix_regexp}}",
+      {% endif %}
       "forceTimeZone": {{ sumologic_collector_force_timezone | default(sumologic_collector_force_timzone) }},
       "timeZone": "{{ sumologic_collector_timezone }}",
       "category": "{{ source.category }}",


### PR DESCRIPTION
SumoLogic has a feature to control multiline match behavior with a regular expression. This PR adds a new optional property to the `sumologic_collector_log_paths` hash, `prefix_regexp`. When present, the new property will be used for multiline matches.

Thanks for this great Ansible playbook -- thought I would contribute a small feature that has been useful for me.