### PR TITLE
initial commit docker-syslog-sumo-collector

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,34 @@
-Role Name
-=========
+SumoCollector
+=============
 
-Ansible role to install SumoCollector. This role was inspired by modcloth's SumoCollector role, but it goes one step further by including the ability to include additional log paths.
+Ansible role to install SumoCollector. This role was based on wgregorian as 
+recommended by Sumo staff.  That was a native install using yum.  
+We now support yum, tarball and docker installs.  Hot patches would likely 
+be first available via tarball for testing bugfixes with sumologic team.
+
+Changelog from wgregorian
+-------------------------
+Switched from single source file to /etc/sumo/sumo.d
+Supports automatic docker app logs if using journald or syslog driver.
+By default installs sumo as systemd unit running a docker container.
+Supports file based (rather than cloud based) management.
+Tunes host to avoid sumo errors setting ulimits.
+Installs sysstat to host for performance monitoring to support Linux Performance Dashboard.
+Sets up cron jobs for sysstat and disk checks.
+Installs monitors for traefik and mesos.
+Installs host metrics to support Host Metrics dashboard
+Transitions from old sumo.conf to recommended user.properties file.
+
+Having extra files in /etc/sumo/sumo.d is not a problem.  If path is not found
+sumo blade will not load.  Sumo watches the sourcefile or folder so changes
+should be taken up automatically without restarting the process.
+
+Currently only the docker install method is fully supported.  
+The yum install seems to lag behind docker and tarball versions
+and sumo support recommended the tar or docker install.
+The docker container closely resembles the tar install (/opt/SumoCollector).
+If a native install is needed, handlers.yml would need to be modified and
+a systemd service based on native install should be written for surviving host shutdowns etc.
 
 Role Variables
 --------------
@@ -9,42 +36,19 @@ Role Variables
 Default variables:
 
 ```
-# For RedHat only
-sumocollector_installer_rpm: "https://collectors.sumologic.com/rest/download/rpm/64"
-sumologic_installer_rpm_local_folder: "/tmp"
+For a complete list see defaults.yml
 
-# For Debian apt installation only
-sumologic_installer_remote_file: "/tmp/sumocollector.deb"
-sumocollector_installer_download: "https://collectors.sumologic.com/rest/download/deb/64"
+deployment_id: Following sumo best practices, there is a top-level deployment_id which sets
+_sourceCategory allowing indexing based on deployment.
 
-# Credentials
-sumologic_collector_accessid: ""
-sumologic_collector_accesskey: ""
+# Credentials.  Set these in your environment or over-ride.
+sumologic_collector_accessid: "{{ lookup('env', 'SUMO_COLLECTOR_ACCESS_ID' }}"
+sumologic_collector_accesskey: "{{ lookup('env', 'SUMO_COLLECTOR_ACCESS_KEY' }}"
 
 # Allow overwrite of old collectors. See:
 #   https://service.sumologic.com/help/Default.htm#Using_Clobber.htm
 sumologic_collector_clobber: ""
 
-sumologic_installer_file: ""
-sumologic_collector_source_template: "collector.json.j2"
-sumologic_collector_timezone: "UTC"
-sumologic_collector_force_timezone: "false"
-sumologic_collector_default_log_path:
-  - name: "EXAMPLE LOG"
-    path: "/var/log/EXAMPLE.log"
-    use_multiline: false
-    category: "EXAMPLE"
-```
-
-Group variable example:
-
-```
-sumologic_collector_application_log_path:
-  - name: "APP LOG"
-    path: "/var/log/APP.log"
-    use_multiline: false
-    category: "APP" }
-```
 
 Example Playbook
 ----------------
@@ -67,6 +71,47 @@ and running:
 
     ansible-galaxy install -r requirements.yml
 
+Example Commandline Options
+---------------------------
+ansible-playbook -i /path/to/hosts site.yml -e sumologic_force_restart=yes -e @/ath/to/over-ride-vars.yml
+
+## Legacy vars for sumo.conf.j2
+These could be migrated to user.properties.
+
+sumologic_installer_file: ""
+sumologic_collector_source_template: "collector.json.j2"
+sumologic_collector_timezone: "UTC"
+sumologic_collector_force_timezone: "false"
+sumologic_collector_default_log_path:
+  - name: "EXAMPLE LOG"
+    path: "/var/log/EXAMPLE.log"
+    use_multiline: false
+    category: "EXAMPLE"
+```
+
+Group variable example:
+
+```
+sumologic_collector_application_log_path:
+  - name: "APP LOG"
+    path: "/var/log/APP.log"
+    use_multiline: false
+    category: "APP" }
+```
+
+Troubleshooting
+---------------
+If there are errors in a source file, it may be difficult to discover.
+You can check in the UI by seeing if the file-name shows up in a collector's sources.  You may inspect the json for the source by clicking the info icon.
+You can find the errors by changing the source while tailing collector.log
+in another shell:
+`> tail -f /path/to/collector.log | grep blade `
+
+Roadmap
+-------
+Add sumo api calls to map docker-stats uuid names to nice container names using HTTP source.
+Add examples of sumo api calls to configure queries and alerts.
+Add dashboard templates via api calls.
 
 License
 -------
@@ -77,3 +122,4 @@ Author Information
 ------------------
 
 William Gregorian - CISO, FutureAdvisor.
+Kesten Broughton - Sr. Devops Engineer, CognitiveScale

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,32 +1,53 @@
 ---
 
+sumologic_collector_root: "{% if sumologic_install_method == 'yum' %}/usr/local/SumoCollector{% else %}/opt/SumoCollector{% endif %}"
+# directory on the host machine to mount into container
+sumologic_host_dir: /opt/SumoCollector
+# default install method to docker
+sumologic_install_method: docker
+# consume multiple sources from /etc/sumo/sumo.d
+sumologic_single_source_file: "no"
+syslog_units_directory: /usr/lib/systemd/system
+
+# directories inside container
+sumologic_config_dir: /etc/sumo
+sumologic_sources_dir: /etc/sumo/sumo.d
+
+sumologic_force_restart: "no"
+sumologic_collector_url: https://collectors.us2.sumologic.com
 # For RedHat only
 sumocollector_installer_rpm: "https://collectors.sumologic.com/rest/download/rpm/64"
 sumologic_installer_rpm_local_folder: "/tmp"
 
+# Example of using ncat to syslog tcp port 514
+# Use this if you don't have docker-daemon --log-driver=journald or json-file.
+# docker-logs.json with journald or json-file logger makes this un-necessary.
+sumologic_install_journal_syslog_service: "no"
+sumologic_remove_tar_install: "no"
+sumologic_remove_yum_install: "no"
 # For Debian apt installation only
 sumologic_installer_remote_file: "/tmp/sumocollector.deb"
-sumocollector_installer_download: ""
+sumocollector_installer_download: "{{ sumo_installer_rpm }}"
 
-# Credentials
-sumologic_collector_accessid: ""
-sumologic_collector_accesskey: ""
+# Credentials (Login to Sumo.  Username -> Preferences -> Create Access Key)
+sumologic_collector_accessid: "{{ lookup('env', 'SUMO_COLLECTOR_ACCESS_ID') }}"
+sumologic_collector_accesskey: "{{ lookup('env', 'SUMO_COLLECTOR_ACCESS_KEY') }}"
+
+# Collection of logs should be index-aware placing logs likely to be searched together
+# into the same index.
+# The category field below + partition rules determines the index
+# Suggested partition rules:
+# sumo_category_major -> cluster supporting rancher/mantl or single orchestration layer
+sumologic_collector_name: "{{ inventory_hostname }}"
 
 # Allow overwrite of old collectors. See:
 #   https://service.sumologic.com/help/Default.htm#Using_Clobber.htm
-sumologic_collector_clobber: ""
+sumologic_collector_clobber: "true"
 
-# Manage this collector, and all of its sources, by deploying a configuration file that can be read locally by this collector.
-# This will disable the ability to edit its sources from the UI and the REST API.
-# See: https://service.sumologic.com/help/Default.htm#cshid=1039
-sumologic_collector_use_local_config: ""
-
-sumologic_installer_file: ""
+# Legacy vars from sumo.conf.  Possibly port to user.properties.
 sumologic_collector_source_template: "collector.json.j2"
 sumologic_collector_timezone: "UTC"
 sumologic_collector_force_timezone: "false"
-sumologic_collector_default_log_path:
-  - name: "Sys Log"
-    path: "/var/log/syslog"
-    use_multiline: false
-    category: "OS/Linux/Syslog"
+
+
+

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,4 +1,32 @@
 ---
+
 - name: 'Restart SumoCollector'
-  command: "/opt/SumoCollector/collector restart"
+  service:
+    name: sumologic-collector
+    state: stopped
   tags: [sumologic, sumologic-collector]
+  notify: 'Restart SumoCollector wait'
+  changed_when: True
+
+# attempt to avoid collectore uuid suffixes caused when
+# restart happens before sumo cloud recognizes old collector is gone.
+- name: 'Restart SumoCollector wait'
+  pause: 
+    seconds: 10
+  tags: [sumologic, sumologic-collector]
+  notify: 'Restart SumoCollector start'
+  changed_when: True
+
+- name: 'Restart SumoCollector start'
+  service:
+    name: sumologic-collector
+    state: started
+  tags: [sumologic, sumologic-collector]
+  changed_when: True
+
+- name: 'Restart journalctl_syslog service'
+  service:
+    name: journalctl_syslog
+    state: restarted
+  tags: [sumologic, sumologic-collector]
+

--- a/tasks/docker_install.yml
+++ b/tasks/docker_install.yml
@@ -1,0 +1,71 @@
+# docker_install.yml
+
+# - set_fact:
+#     updated_sumologic_docker_options: "{{sumologic_docker_options}} -v /var/log/sa:/var/log/sa"
+#   when: sumologic_do_sysstat == "yes"
+#   tags:
+#     - sumologic
+#     - sumologic_docker
+
+# - debug: msg="{{updated_sumologic_docker_options}}"
+#   tags:
+#     - sumologic
+#     - sumologic_docker
+
+- name: install systemd unit for sumologic 
+  template:
+    src: sumologic-collector.service
+    dest: "{{ syslog_units_directory }}/sumologic-collector.service"
+    mode: 0700
+  notify: Restart Sumocollector
+  tags: [sumologic, sumologic_docker]
+
+- name: install systemd unit for journalctl to customize docker jounald logs 
+  template:
+    src: journalctl_syslog.service
+    dest: "{{ syslog_units_directory }}/journalctl_syslog.service"
+    mode: 0700
+  notify: Restart journalctl_syslog service
+  tags: [sumologic, sumologic_docker]
+  when: sumologic_install_journal_syslog_service
+
+- name: enable systemd units for sumologic-collector
+  shell: creates="/home/{{ ansible_ssh_user }}/.ansible/markers/{{ item }}" systemctl enable "{{ item }}"  
+  with_items:
+    - sumologic-collector.service
+    - journalctl_syslog.service
+  tags: [sumologic, sumologic_docker]
+
+- name: enable systemd units for journalctl_syslog
+  shell: creates="/home/{{ ansible_ssh_user }}/.ansible/markers/{{ item }}" systemctl enable "{{ item }}"  
+  with_items:
+    - sumologic-collector.service
+    - journalctl_syslog.service
+  tags: [sumologic, sumologic_docker]
+  when: sumologic_install_journal_syslog_service == "yes"
+
+- name: start systemd unit for sumologic-collector
+  service: 
+    name: "{{ item }}"
+    state: started
+  with_items:
+    - sumologic-collector.service
+  tags: [sumologic, sumologic_docker]
+
+- name: start systemd unit for journalctl_syslog
+  service: 
+    name: "{{ item }}"
+    state: started
+  with_items:
+    - journalctl_syslog.service
+  tags: [sumologic, sumologic_docker]
+  when: sumologic_install_journal_syslog_service == "yes"
+
+- name: force stop journalctl_syslog service
+  service: 
+    name: "{{ item }}"
+    state: stopped
+  with_items:
+    - journalctl_syslog.service
+  tags: [sumologic, sumologic_docker]
+  when: (sumologic_force_restart == "yes") and (sumologic_install_method != "docker")

--- a/tasks/linux_performance.yml
+++ b/tasks/linux_performance.yml
@@ -1,0 +1,18 @@
+# linux_performance.yml
+
+# https://help.sumologic.com/Apps/Linux_Performance_App/Collect_Logs_for_the_Linux_Performance_App
+# http://sebastien.godard.pagesperso-orange.fr/man_sadf.html
+- name: install sysstat
+  yum:
+    name: sysstat
+  tags: 
+   - sumologic
+   - sumo-perf
+
+- name: template cron for sysstat
+  template:
+    src: etc_cron.d_sysstat
+    dest: /etc/cron.d/sysstat
+  tags: 
+    - sumologic
+    - sumo-perf

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,27 +1,55 @@
 ---
-- name: 'Check for SumoCollector'
-  command: dpkg-query -l sumocollector
-  register: sumologic_collector_deb_check
-  failed_when: no
-  tags: sumologic
 
-- name: 'Download SumoCollector'
-  get_url:
-    url: '{{ sumocollector_installer_download }}'
-    dest: '{{ sumologic_installer_remote_file }}'
-  when: sumologic_collector_deb_check.rc == 1
-  tags: sumologic
+# sumo.conf is deprecated in prefence of user.properties
+# This should be sym-linked by /opt/SumoCollector/config/user.properties
+# in mounted into container
+- name: 'Ensure sumologic_config_dir exists'
+  file:
+    state: directory
+    dest: "{{ sumologic_config_dir }}"
+    mode: 0700
+    owner: "{{ ansible_ssh_user }}"
+  tags: [sumologic, sumologic-collector]
 
-- name: 'Download SumoCollector redhat'
-  get_url:
-    url: '{{ sumocollector_installer_rpm }}'
-    dest: '{{ sumologic_installer_rpm_local_folder }}/sumo_collector.rpm'
-  when: ansible_os_family == "RedHat"
-  tags: sumologic
+- name: 'Template SumoCollector files'
+  template:
+    src: "{{ item }}"
+    dest: "{{ sumologic_config_dir }}/{{item}}"
+    mode: 0700
+    owner: "{{ ansible_ssh_user }}"
+  tags: [sumologic, sumologic-collector]
+  notify: Restart SumoCollector
+  with_items:
+    - sumo-perf-script.sh 
+    - user.properties
+    - sumo-env.sh
+    - sumo-check-disk.sh
 
-- name: 'Define initial SumoCollector sources'
-  set_fact:
-    sumologic_collector_log_paths: "{{ sumologic_collector_default_log_path|list + sumologic_collector_application_log_path|list }}"
+- name: 'Optionally stop sumo'
+  shell: "{{ sumologic_collector_root}}/collector stop"
+  tags: [sumologic, sumologic-collector]
+  when: sumologic_remove_tar_install == "yes"
+  ignore_errors: yes
+
+- name: 'Optionally delete tar install'
+  file:
+    state: absent
+    dest: /opt/SumoCollector
+  tags: [sumologic, sumologic-collector]
+  when: sumologic_remove_tar_install == "yes"
+  ignore_errors: yes
+
+- name: 'Optionally delete yum install'
+  yum:
+    state: absent
+  tags: [sumologic, sumologic-collector]
+  when: sumologic_remove_yum_install == "yes"
+  ignore_errors: yes
+
+- name: 'Template cron for disk stats'
+  template:
+    src: etc_cron.d_disk
+    dest: /etc/cron.d/disk
   tags: [sumologic, sumologic-collector]
 
 - name: 'Create collector configuration'
@@ -30,27 +58,64 @@
     dest: /etc/sumologic-collector.json
   tags: [sumologic, sumologic-collector]
   notify: Restart SumoCollector
+  when: sumologic_single_source_file == "yes"
 
-- name: 'Configure SumoCollector'
+- name: 'Ensure sumo sources directory exists'
+  file:
+    state: directory
+    dest: "{{ sumologic_sources_dir }}"
+  tags: [sumologic, sumologic-collector]
+  when: sumologic_single_source_file != "yes"
+
+- name: 'Ensure sumo temp data and logs dir exists'
+  file:
+    state: directory
+    dest: "{{ sumologic_host_dir }}"
+  tags: [sumologic, sumologic-collector]
+
+- name: 'Template sources'
   template:
-    src: sumo.conf.j2
-    dest: /etc/sumo.conf
-  register: sumologic_collector_add_configuration
-  tags: sumologic
-  notify: Restart SumoCollector
+    src: ../templates/sources/{{ item | basename }}
+    dest: "{{ sumologic_sources_dir }}"
+  tags: [sumologic, sumologic-collector]
+  when: sumologic_single_source_file != "yes" 
+  with_fileglob: ../templates/sources/*
 
-- name: 'Install SumoCollector'
-  apt:
-    deb: '{{ sumologic_installer_remote_file }}'
-    state: installed
-  when: sumologic_collector_deb_check.rc == 1
-  tags: sumologic
-  notify: Restart SumoCollector
+- include: linux_performance.yml
+  tags: [sumologic, sumologic-collector]
+  when: sumologic_do_sysstat | default(False)
 
-- name: 'Install SumoCollector redhat'
-  yum:
-    name: '{{ sumologic_installer_rpm_local_folder }}/sumo_collector.rpm'
-    state: present
-  when: ansible_os_family == "RedHat"
-  tags: sumologic
-  notify: Restart SumoCollector
+- include: native_install.yml
+  when: sumologic_install_method == "yum"
+  tags: [sumologic, sumologic-collector]
+
+- include: docker_install.yml
+  when: sumologic_install_method == "docker"
+  tags: [sumologic, sumologic-collector]
+
+- name: 'Set udp limits for sumo (native and inherited by container)'
+  shell: "{{ item }}"
+  with_items:
+   - sysctl -w net.core.wmem_max=8388608
+   - sysctl -w net.core.rmem_max=8388608
+  tags: [sumologic, sumologic-collector]
+
+- name: 'Ensure collector is running'
+  service: 
+    name: "{{ item }}"
+    state: started
+  with_items:
+    - sumologic-collector.service
+  when: sumologic_install_method == "docker"
+  tags: [sumologic, sumologic_docker]
+
+- name: 'Force restart SumoCollector'
+  shell: "{{ sumologic_collector_root }}/collector restart"
+  tags: [sumologic, sumologic-collector, sumologic_force_restart]
+  when: (sumologic_force_restart == "yes") and (sumologic_install_method != "docker")
+  
+- name: 'Force restart SumoCollector docker'
+  shell: echo "restarting docker"
+  tags: [sumologic, sumologic-collector, sumologic_force_restart]
+  when: (sumologic_force_restart == "yes") and (sumologic_install_method == "docker")
+  notify: 'Restart SumoCollector'

--- a/tasks/mongodb_app.yml
+++ b/tasks/mongodb_app.yml
@@ -1,0 +1,4 @@
+# mongodb_app.yml
+
+
+# https://help.sumologic.com/Apps/MongoDB/Collect_Logs_for_MongoDB

--- a/tasks/native_install.yml
+++ b/tasks/native_install.yml
@@ -1,0 +1,50 @@
+# native_install.yml
+
+- name: Install sumo with sumo installer
+  shell: wget "https://collectors.us2.sumologic.com/rest/download/linux/64" -O SumoCollector.sh && sudo chmod +x SumoCollector.sh && sudo ./SumoCollector.sh -q -Vsumo.token_and_url=MDQxdEdweHNLMDNtd210SDg3SENsSU0wMW1ZSGIzcDVodHRwczovL2NvbGxlY3RvcnMudXMyLnN1bW9sb2dpYy5jb20=
+  tags: [sumologic, sumologic_token_installer]
+  when: sumologic_token_installer is defined
+
+- name: 'Check for SumoCollector on Debian'
+  command: dpkg-query -l sumocollector
+  register: sumologic_collector_deb_check
+  failed_when: no
+  tags: [sumologic, sumologic_force_restart]
+  #when: ansible_os_family == "Debian"
+
+- name: 'Download SumoCollector for Debian'
+  get_url:
+    url: '{{ sumocollector_installer_download }}'
+    dest: '{{ sumologic_installer_remote_file }}'
+  when: ( sumologic_collector_deb_check.rc == 1 ) and ( ansible_os_family == "Debian" )
+  tags: [sumologic, sumologic_force_restart]
+
+- name: 'Install SumoCollector for Debian'
+  apt:
+    deb: '{{ sumologic_installer_remote_file }}'
+    state: installed
+  when: ( sumologic_collector_deb_check.rc == 1 ) and ( ansible_os_family == "Debian" )
+  tags: sumologic
+  notify: Restart SumoCollector
+
+- name: 'Check for SumoCollector on RedHat'
+  command: yum list *sumo_collector*
+  register: sumologic_collector_yum_check
+  failed_when: no
+  tags: [sumologic, sumologic_force_restart]
+  #when: ansible_os_family == "RedHat"
+
+- name: 'Download SumoCollector redhat'
+  get_url:
+    url: '{{ sumocollector_installer_rpm }}'
+    dest: '{{ sumologic_installer_rpm_local_folder }}/sumo_collector.rpm'
+  when: ( sumologic_collector_yum_check.rc == 1 ) and ( ansible_os_family == "RedHat" )
+  tags: [sumologic, sumologic_force_restart]
+
+- name: 'Install SumoCollector redhat'
+  yum:
+    name: '{{ sumologic_installer_rpm_local_folder }}/sumo_collector.rpm'
+    state: present
+  when: ( sumologic_collector_yum_check.rc == 1 ) and ( ansible_os_family == "RedHat" ) 
+  tags: [sumologic, sumologic_force_restart]
+  notify: Restart SumoCollector

--- a/templates/collector.json.j2
+++ b/templates/collector.json.j2
@@ -1,24 +1,55 @@
 {
   "api.version": "v1",
   "sources": [
-{% for source in sumologic_collector_log_paths %}
+{% for source in sumologic_collector_log_paths['common'] %}
+    {{ source |to_nice_json }}{% if not loop.last %},{% endif %}
+
+{% endfor %}{% if inventory_hostname in groups['role=worker'] %},
+{% for source in sumologic_collector_log_paths['worker'] %}
     {
       "name": "{{ source.name }}",
       "sourceType": "LocalFile",
       "automaticDateParsing": true,
-      "multilineProcessingEnabled": "{{ source.use_multiline }}",
-      "useAutolineMatching": {{'false' if source.prefix_regexp is defined else 'true'}},
-      {% if source.prefix_regexp is defined %}
-      "manualPrefixRegexp": "{{source.prefix_regexp}}",
-      {% endif %}
+      "multilineProcessingEnabled": "{{ source.use_multiline | default(false) }}",
+      "useAutolineMatching": true,
+      "forceTimeZone": {{ sumologic_collector_force_timezone | default(sumologic_collector_force_timzone) }},
+      "timeZone": "{{ sumologic_collector_timezone }}",
+      "category": "{{ source.category }}",
+      "pathExpression": "{{ source.path }}"
+    }{% if not loop.last %},{% endif %}
+{% endfor %}
+{% endif %}
+{% if inventory_hostname in groups['role=control'] %},
+{% for source in sumologic_collector_log_paths['control'] %}
+    {
+      "name": "{{ source.name }}",
+      "sourceType": "LocalFile",
+      "automaticDateParsing": true,
+      "multilineProcessingEnabled": "{{ source.use_multiline | default(false) }}",
+      "useAutolineMatching": true,
       "forceTimeZone": {{ sumologic_collector_force_timezone | default(sumologic_collector_force_timzone) }},
       "timeZone": "{{ sumologic_collector_timezone }}",
       "category": "{{ source.category }}",
       "pathExpression": "{{ source.path }}"
     }
-    {% if not loop.last %}
-        ,
-    {% endif %}
+    {% if not loop.last %},{% endif %}
 {% endfor %}
+{% endif %}
+
+{% if inventory_hostname in groups['role=edge'] %},
+{% for source in sumologic_collector_log_paths['edge'] %}
+    {
+      "name": "{{ source.name }}",
+      "sourceType": "LocalFile",
+      "automaticDateParsing": true,
+      "multilineProcessingEnabled": "{{ source.use_multiline | default(false) }}",
+      "useAutolineMatching": true,
+      "forceTimeZone": {{ sumologic_collector_force_timezone | default(sumologic_collector_force_timzone) }},
+      "timeZone": "{{ sumologic_collector_timezone }}",
+      "category": "{{ source.category }}",
+      "pathExpression": "{{ source.path }}"
+    }{% if not loop.last %},{% endif %}
+{% endfor %}
+{% endif %}
   ]
 }

--- a/templates/etc_cron.d_disk
+++ b/templates/etc_cron.d_disk
@@ -1,0 +1,5 @@
+# etc_cron.d_disk
+# "{{ ansible_managed }}"
+
+# Run df summary every minute
+* * * * * root /etc/sumo/sumo-check-disk.sh | /usr/bin/ncat localhost 514

--- a/templates/etc_cron.d_sysstat
+++ b/templates/etc_cron.d_sysstat
@@ -1,0 +1,7 @@
+# "{{ ansible_managed }}"
+
+# Run system activity accounting tool every 2 minutes
+*/2 * * * * root /usr/lib64/sa/sa1 -S DISK 1 1
+# 0 * * * * root /usr/lib64/sa/sa1 600 6 &
+# Generate a daily summary of process accounting at 23:53
+53 23 * * * root /usr/lib64/sa/sa2 -A

--- a/templates/hosted_sources/sumo_http_source.json
+++ b/templates/hosted_sources/sumo_http_source.json
@@ -1,0 +1,8 @@
+{
+   "api.version":"v1",
+   "source":{
+      "sourceType":"HTTP",
+      "name":"Example1",
+      "messagePerRequest": true
+   }
+}

--- a/templates/journalctl_syslog.service
+++ b/templates/journalctl_syslog.service
@@ -1,0 +1,16 @@
+# {{ ansible_managed }}
+# journalctl_syslog.service
+# /etc/systemd/system/journalctl_syslog.service
+
+[Unit]
+Description=Send Journalctl to Sumo
+
+[Service]
+TimeoutStartSec=0
+ExecStart=/bin/bash -c '/usr/bin/journalctl -o json -f | jq -c \'. | select(._COMM | . and contains ("docker")) | {"__REALTIME_TIMESTAMP":.__REALTIME_TIMESTAMP,"CONTAINER_TAG":.CONTAINER_TAG, "_HOSTNAME":._HOSTNAME,"MESSAGE":."MESSAGE", "CONTAINER_ID":.CONTAINER_ID,"CONTAINER_NAME":.CONTAINER_NAME}\' | /usr/bin/ncat localhost 514'
+
+Restart=always
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target

--- a/templates/sources/access-log.json
+++ b/templates/sources/access-log.json
@@ -1,0 +1,9 @@
+{
+  "api.version": "v1",
+  "source": {
+      "name": "Access-Log",
+      "sourceType": "LocalFile",
+      "pathExpression": "/var/log/audit/*",
+      "category": "{{ deployment_id }}/os/access"
+     }
+} 

--- a/templates/sources/docker-logs.json
+++ b/templates/sources/docker-logs.json
@@ -1,0 +1,12 @@
+{
+  "api.version": "v1",
+  "source": {
+      "name": "Docker-Logs",
+      "allContainers": true,
+      "collectEvents": true,
+      "uri": "unix:///var/run/docker.sock",
+      "multilineProcessingEnabled": false,
+      "sourceType": "DockerLog",
+      "category": "{{ deployment_id }}/containers"
+   }
+}

--- a/templates/sources/docker-stats.json
+++ b/templates/sources/docker-stats.json
@@ -1,0 +1,18 @@
+{
+  "api.version": "v1",
+  "source": {
+      "name": "Docker-Stats",
+      "alive": true,
+      "allContainers": true,
+      "certPath": "",
+      "filters": [{
+         "filterType": "Include",
+         "name": "StatsRateLimiter",
+         "regexp": "\\{\\\"read\\\"\\s:\\s\\\"\\d{4}-\\d{2}-\\w{5}:\\d{2}:[0][0|1|2].*"
+        }],
+      "multilineProcessingEnabled": true,
+      "sourceType": "DockerStats",
+      "uri": "unix:///var/run/docker.sock",
+      "category": "{{ deployment_id }}/infra/docker"
+     }
+}

--- a/templates/sources/host-metrics.json
+++ b/templates/sources/host-metrics.json
@@ -1,0 +1,11 @@
+{
+ "api.version": "v1",
+ "source": {
+   "sourceType" : "SystemStats",
+   "category": "{{ deployment_id }}/os/perf",
+   "name": "Host-Metrics",
+   "interval" : 240000,
+   "hostName" : "{{ inventory_hostname }}",
+   "contentType":"HostMetrics"
+ }
+}

--- a/templates/sources/mesos.json
+++ b/templates/sources/mesos.json
@@ -1,0 +1,15 @@
+{
+  "api.version": "v1",
+  "source": {
+      "name": "Mesos",
+      "sourceType": "LocalFile",
+      "automaticDateParsing": true,
+      "multilineProcessingEnabled": "False",
+      "useAutolineMatching": true,
+      "forceTimeZone": false,
+      "timeZone": "UTC",
+      "pathExpression": "/var/log/mesos/*.log*",
+      "blacklist": ["/var/log/mesos/*.gz*"],
+      "category": "{{ deployment_id }}/infra/mesos"
+    }
+}

--- a/templates/sources/sar-sysstat.json
+++ b/templates/sources/sar-sysstat.json
@@ -1,0 +1,24 @@
+{
+  "api.version": "v1",
+  "source": {
+    "name":"SAR-sysstat",
+    "description":"Test",
+    "automaticDateParsing":true,
+    "multilineProcessingEnabled":true,
+    "useAutolineMatching":false,
+    "manualPrefixRegexp": "^\\{\\\"sysstat\\\":.*",
+    "forceTimeZone":false,
+    "filters":[],
+    "cutoffTimestamp":0,
+    "encoding":"UTF-8",
+    "file":"/etc/sumo/sumo-perf-script.sh",
+    "script":null,
+    "cronExpression":"0/10 * * * * ? *",
+    "timeout":300000,
+    "workingDir":"",
+    "commands":["/bin/sh"],
+    "extension":null,
+    "sourceType":"Script",
+    "category":"{{ deployment_id }}/os/perf"
+  }
+}

--- a/templates/sources/security-log.json
+++ b/templates/sources/security-log.json
@@ -1,0 +1,9 @@
+{
+  "api.version": "v1",
+  "source": {
+      "name": "Security-Log",
+      "sourceType": "LocalFile",
+      "pathExpression": "/var/log/secure*",
+      "category": "{{ deployment_id }}/os/secure"
+    }
+}

--- a/templates/sources/syslog-collector-container-tcp.json
+++ b/templates/sources/syslog-collector-container-tcp.json
@@ -1,0 +1,14 @@
+{
+  "api.version": "v1",
+  "source": {
+      "name": "syslog-collector-container-tcp",
+      "sourceType": "Syslog",
+      "multilineProcessingEnabled":true,
+      "useAutolineMatching":true,
+      "port": 514,
+      "protocol": "TCP",
+      "encoding": "UTF-8",
+      "forceTimeZone": false,
+      "category": "{{ deployment_id }}/os/syslog-port"
+   }
+}

--- a/templates/sources/syslog-collector-container-udp.json
+++ b/templates/sources/syslog-collector-container-udp.json
@@ -1,0 +1,14 @@
+{
+  "api.version": "v1",
+  "source": {
+      "name": "syslog-collector-container-udp",
+      "sourceType": "Syslog",
+      "port": 514,
+      "multilineProcessingEnabled":true,
+      "useAutolineMatching":true,
+      "protocol": "UDP",
+      "encoding": "UTF-8",
+      "forceTimeZone": false,
+      "category": "{{ deployment_id }}/os/syslog-port"
+   }
+}

--- a/templates/sources/syslog.json
+++ b/templates/sources/syslog.json
@@ -1,0 +1,34 @@
+{
+  "api.version": "v1",
+  "source": {
+      "name": "Syslog",
+      "filters": [{
+        "filterType": "Exclude",
+        "name": "kubernetes",
+        "regexp": ".*kube.*"
+        }, 
+        {
+          "filterType": "Exclude",
+          "name": "RPC request for DC",
+          "regexp": ".*RPC\\srequest\\sfor\\DC.*"
+        }, 
+        {
+          "filterType": "Exclude",
+          "name": "no path to datacenter",
+          "regexp": "No path to datacenter"
+        },
+        {
+          "filterType": "Exclude",
+          "name": "journald docker logs",
+          "regexp": ".*journal:.*"
+        }, 
+        {
+          "filterType": "Exclude",
+          "name": "etcd",
+          "regexp": ".*etcd.*"
+        }],
+       "sourceType": "LocalFile",
+       "pathExpression": "/var/log/messages*",
+       "category": "{{ deployment_id }}/os/syslog"
+    }
+}

--- a/templates/sources/traefik-logs.json
+++ b/templates/sources/traefik-logs.json
@@ -1,0 +1,9 @@
+  {
+  "api.version": "v1",
+  "source": {
+      "name": "Traefik-Logs",
+      "sourceType": "LocalFile",
+      "pathExpression": "/var/log/traefik/*.log*",
+      "category": "{{ deployment_id }}/infra/traefik"
+     }
+} 

--- a/templates/sumo-check-disk.sh
+++ b/templates/sumo-check-disk.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+# {{ ansible_managed }}
+FIRST=true
+echo -n {\"disk_util_percent\": {
+df -H | grep -vE '^Filesystem|tmpfs|cdrom' | awk '{ print "\""$1"\"" ": " $5 }' | sed s/%// | while read output;
+do
+  if [[ $FIRST == "true" ]];then
+     echo -n $output
+     FIRST=false
+  else
+     echo -n ", $output"
+  fi
+done
+echo }}

--- a/templates/sumo-env.sh
+++ b/templates/sumo-env.sh
@@ -1,0 +1,15 @@
+# sumo-env.sh
+
+# {{ ansible_managed }}
+
+# For use with docker sumologic container
+
+SUMO_ACCESS_ID="{{ sumologic_collector_accessid }}"
+SUMO_ACCESS_KEY="{{ sumologic_collector_accesskey }}"
+# also defined in /etc/sumo/sumo.conf
+SUMO_COLLECTOR_NAME={{ inventory_hostname }}
+{% if sumologic_single_source_file == "yes" %}
+SUMO_SOURCES_JSON=/etc/sumo/sumologic-collector.json
+{% else %}
+SUMO_SOURCES_JSON=/etc/sumo/sumo.d 
+{% endif %}

--- a/templates/sumo-perf-script.sh
+++ b/templates/sumo-perf-script.sh
@@ -1,0 +1,4 @@
+# sumo-perf-script.sh
+# {{ ansible_managed }}
+
+/usr/bin/sadf -T -j -s $(/bin/date -d "-4 minute" +%T) -- 1 1 -A -dp 

--- a/templates/sumo.conf.j2
+++ b/templates/sumo.conf.j2
@@ -18,9 +18,6 @@ accesskey={{ sumologic_collector_accesskey }}
 {% if sumologic_collector_source_template is defined %}
 sources=/etc/sumologic-collector.json
 {% endif %}
-{% if sumologic_collector_use_local_config is defined and sumologic_collector_use_local_config != "" %}
-syncSources=/etc/sumologic-collector.json
-{% endif %}
 {% if sumologic_collector_override is defined %}
 override={{ sumologic_collector_override }}
 {% endif %}

--- a/templates/sumologic-collector.service
+++ b/templates/sumologic-collector.service
@@ -1,0 +1,40 @@
+# {{ansible_managed}}
+# sumologic-collector.service
+
+[Unit]
+Description=sumologic-collector
+After=docker.service
+After=consul.service
+Requires=docker.service
+Wants=consul.service
+
+[Service]
+Restart=on-failure
+RestartSec=20
+TimeoutStartSec=0
+
+ExecStartPre=-/usr/bin/docker kill sumologic-collector
+ExecStartPre=-/usr/bin/docker rm -f sumologic-collector
+ExecStartPre=-/usr/bin/docker pull sumologic/collector:latest-syslog
+
+ExecStart=/usr/bin/docker run \
+    --rm \
+    -p 514:514 -p 514:514/udp \
+    --name=sumologic-collector \
+    --env-file=/etc/sumo/sumo-env.sh \
+    -v /usr/bin/sadf:/usr/bin/sadf \
+    -v /var/log:/var/log \
+    -v /dev/mapper:/dev/mapper \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    -v /cs/beanstalk/sumo/logs:/opt/SumoCollector/logs \
+    -v /cs/beanstalk/sumo/data:/opt/SumoCollector/data \
+    -v /etc/sumo:/etc/sumo \
+    -v /etc/sumo/user.properties:/opt/SumoCollector/config/user.properties \
+      sumologic/collector:latest-syslog {{ sumologic_collector_accessid }} {{ sumologic_collector_accesskey }}
+
+ExecStop=/usr/bin/docker kill sumologic-collector
+
+ExecReload=/usr/bin/docker kill -s SIGHUP sumologic-collector
+
+[Install]
+WantedBy=multi-user.target

--- a/templates/user.properties
+++ b/templates/user.properties
@@ -1,0 +1,10 @@
+# user.properties
+
+# "{{ ansible_managed }}"
+
+url="{{ sumologic_collector_url }}"
+name={{ sumologic_collector_name }}
+accessid="{{ sumologic_collector_accessid }}"
+accesskey="{{ sumologic_collector_accesskey }}"
+syncSources="{{ sumologic_sources_dir }}"
+clobber={{ sumologic_collector_clobber }}


### PR DESCRIPTION
See Readme for more details:

Ansible role to install SumoCollector. This role was based on wgregorian as 
recommended by Sumo staff.  That was a native install using yum.  
We now support yum, tarball and docker installs.  Hot patches would likely 
be first available via tarball for testing bugfixes with sumologic team.
## Changelog from wgregorian

Switched from single source file to /etc/sumo/sumo.d
Supports automatic docker app logs if using journald or syslog driver.
By default installs sumo as systemd unit running a docker container.
Supports file based (rather than cloud based) management.
Tunes host to avoid sumo errors setting ulimits.
Installs sysstat to host for performance monitoring to support Linux Performance Dashboard.
Sets up cron jobs for sysstat and disk checks.
Installs monitors for traefik and mesos.
Installs host metrics to support Host Metrics dashboard
Transitions from old sumo.conf to recommended user.properties file.
